### PR TITLE
(Feature) Allow buildspec declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ The following variables can be configured:
 - **Description**: S3 bucket to store status badge and artifacts
 - **Default**: `"github-ci"` (equal to namespace)
 
+#### `codebuild_buildspec`
+
+- **Description**: The build spec declaration to use for this build project's related builds.
+- **Default**: `""`
+
 ### Outputs
 
 The following outputs are exported:

--- a/main.tf
+++ b/main.tf
@@ -123,8 +123,9 @@ resource "aws_codebuild_project" "_" {
   service_role  = "${aws_iam_role.codebuild.arn}"
 
   source {
-    type     = "GITHUB"
-    location = "${data.template_file.codebuild_source_location.rendered}"
+    type      = "GITHUB"
+    location  = "${data.template_file.codebuild_source_location.rendered}"
+    buildspec = "${var.codebuild_buildspec}"
 
     auth {
       type     = "OAUTH"

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "codebuild_bucket" {
   description = "S3 bucket to store status badge and artifacts"
   default     = ""
 }
+
+# var.codebuild_buildspec
+variable "codebuild_buildspec" {
+  description = "The build spec declaration to use for this build project's related builds."
+  default     = ""
+}


### PR DESCRIPTION
* Adds ability to change the buildspec declaration for the CodeBuild
project
* `codebuild_buildspec` variable defaults to `""`, which defaults to
`buildspec.yml` in AWS