### PR TITLE
(Feature) Support CodeBuild Environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ The following variables can be configured:
 - **Description**: S3 bucket to store status badge and artifacts
 - **Default**: `"${var.namespace}"` (equal to namespace)
 
+#### `codebuild_environment_variables`
+- **Description**: CodeBuild Environment variables
+- **Deafult**: []
+- **Conflicts with**: `codebuild_project`
+
 ### Outputs
 
 The following outputs are exported:

--- a/main.tf
+++ b/main.tf
@@ -132,10 +132,11 @@ resource "aws_codebuild_project" "_" {
   }
 
   environment {
-    compute_type    = "${var.codebuild_compute_type}"
-    type            = "LINUX_CONTAINER"
-    image           = "${var.codebuild_image}"
-    privileged_mode = "${var.codebuild_privileged_mode}"
+    compute_type         = "${var.codebuild_compute_type}"
+    type                 = "LINUX_CONTAINER"
+    image                = "${var.codebuild_image}"
+    privileged_mode      = "${var.codebuild_privileged_mode}"
+    environment_variable = "${var.codebuild_environment_variables}"
   }
 
   artifacts {

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,10 @@ variable "codebuild_bucket" {
   description = "S3 bucket to store status badge and artifacts"
   default     = ""
 }
+
+# var.codebuild_environment_variables
+variable "codebuild_environment_variables" {
+  description = "CodeBuild Environment Variables"
+  default     = []
+  type        = "list"
+}


### PR DESCRIPTION
* Although undocumented, `environment_variable` can take a list of
environment variables - https://github.com/terraform-providers/terraform-provider-aws/issues/5563